### PR TITLE
chore: remove unused imports and variables

### DIFF
--- a/src/common/Loading/index.jsx
+++ b/src/common/Loading/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { useLoading } from 'contexts/loadingContext';
 

--- a/src/components/Admin/AdminRouter/index.jsx
+++ b/src/components/Admin/AdminRouter/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes, Navigate } from 'react-router-dom';
 import { useAuth } from 'contexts/authContext';
 import ManyChargeComponent from 'components/Admin/Transaction/ManyCharge';

--- a/src/components/Admin/Auth/AdminLogin/index.jsx
+++ b/src/components/Admin/Auth/AdminLogin/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from 'contexts/authContext';
 import * as L from './style';

--- a/src/components/Admin/Auth/UserList/index.jsx
+++ b/src/components/Admin/Auth/UserList/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import DataTable from 'pages/Admin/TablePage';
 import axiosInstance from 'utils/Axios';
 

--- a/src/components/Admin/Inventory/InventoryByDay/index.jsx
+++ b/src/components/Admin/Inventory/InventoryByDay/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState, useRef } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import DataTablePage from 'pages/Admin/TablePage';
 import axiosInstance from 'utils/Axios';

--- a/src/components/Admin/Inventory/InventoryCheck/StockBarcode.js
+++ b/src/components/Admin/Inventory/InventoryCheck/StockBarcode.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import axiosInstance from 'utils/Axios';
 import Modal from 'components/Modal';
 import * as _ from './style';

--- a/src/components/Admin/Inventory/InventoryCheck/index.jsx
+++ b/src/components/Admin/Inventory/InventoryCheck/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import DataTable from 'pages/Admin/TablePage';
 import axiosInstance from 'utils/Axios';
 import { PrettyDateTime } from 'utils/Date';

--- a/src/components/Admin/Inventory/ItemInfo/index.jsx
+++ b/src/components/Admin/Inventory/ItemInfo/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import DataTable from 'pages/Admin/TablePage';
 import axiosInstance from 'utils/Axios';
 

--- a/src/components/Admin/Inventory/ReceiptCheck/index.jsx
+++ b/src/components/Admin/Inventory/ReceiptCheck/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import DataTablePage from 'pages/Admin/TablePage';
 import axiosInstance from 'utils/Axios';
 import { PrettyDateTime } from 'utils/Date';

--- a/src/components/Admin/Inventory/Stock/index.jsx
+++ b/src/components/Admin/Inventory/Stock/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Modal from 'components/Modal';
 
 const Stock = () => {

--- a/src/components/Admin/Inventory/StockVariance/StockVarianceItem/index.jsx
+++ b/src/components/Admin/Inventory/StockVariance/StockVarianceItem/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import * as _ from './style';
 import styled from 'styled-components';
 import { PrettyDateTime } from 'utils/Date';

--- a/src/components/Admin/Inventory/StockVariance/index.jsx
+++ b/src/components/Admin/Inventory/StockVariance/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import * as _ from './style';
 import * as P from 'common/PageWrapStyle';
 import { useNavigate } from 'react-router-dom';

--- a/src/components/Admin/PointManage/ChargeList/index.jsx
+++ b/src/components/Admin/PointManage/ChargeList/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import TablePage from 'pages/Admin/TablePage';
 import axiosInstance from 'utils/Axios';
 import { PrettyDateTime } from 'utils/Date';

--- a/src/components/Admin/PointManage/PayList/index.jsx
+++ b/src/components/Admin/PointManage/PayList/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import DataTablePage from 'pages/Admin/TablePage';
 import axiosInstance from 'utils/Axios';
 import { PrettyDateTime } from 'utils/Date';

--- a/src/components/Admin/Transaction/Barcode/index.jsx
+++ b/src/components/Admin/Transaction/Barcode/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import { useState, useRef } from 'react';
 import axiosInstance from 'utils/Axios';
 import { useNavigate } from 'react-router-dom';
 import * as _ from './style'; // 스타일 파일을 임포트
@@ -41,7 +41,7 @@ export const Barcode = () => {
           userCode,
         },
       });
-    } catch (error) {
+    } catch (_error) {
       setErrorMessage('바코드 인식에 실패했습니다. 다시 시도해주세요.');
       setUserCode(''); // 바코드 입력창을 초기화
       inputRef.current.focus(); // 입력창에 포커스 맞추기

--- a/src/components/Admin/Transaction/Complete/index.jsx
+++ b/src/components/Admin/Transaction/Complete/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import * as _ from './style';
 import { color } from 'constants/color';

--- a/src/components/Admin/Transaction/ManyCharge/ChargeModal/index.jsx
+++ b/src/components/Admin/Transaction/ManyCharge/ChargeModal/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Modal from 'components/Modal';
 import * as S from './style';
 import axiosInstance from 'utils/Axios';

--- a/src/components/Admin/Transaction/ManyCharge/ManyChargeItem/index.jsx
+++ b/src/components/Admin/Transaction/ManyCharge/ManyChargeItem/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import * as _ from './style';
 import styled from 'styled-components';
 

--- a/src/components/Admin/Transaction/ManyCharge/index.jsx
+++ b/src/components/Admin/Transaction/ManyCharge/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import * as _ from './style';
 import * as P from 'common/PageWrapStyle';
 import { ManyChargeItem } from './ManyChargeItem';

--- a/src/components/Admin/Transaction/Payments/index.jsx
+++ b/src/components/Admin/Transaction/Payments/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import PaymentsCheck from '../TransactionCheck'; // 통합된 체크 컴포넌트 사용
 import TransactionLog from '../TransactionLog'; // 통합된 로그 컴포넌트 사용
 import * as C from '../Complete/style';

--- a/src/components/Admin/Transaction/TransactionCheck/index.jsx
+++ b/src/components/Admin/Transaction/TransactionCheck/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Modal from 'components/Modal';
 import { useNavigate } from 'react-router-dom';
 import * as _ from './style';

--- a/src/components/Admin/Transaction/TransactionLog/index.jsx
+++ b/src/components/Admin/Transaction/TransactionLog/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as _ from './style.js'; // 스타일 파일을 _로 매핑
 import { PrettyDateTime } from 'utils/Date';
 import axiosInstance from 'utils/Axios';

--- a/src/components/PWA/InstallPrompt.jsx
+++ b/src/components/PWA/InstallPrompt.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
 const InstallPrompt = () => {

--- a/src/components/User/HowTo/index.jsx
+++ b/src/components/User/HowTo/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './style';
 

--- a/src/components/User/Register/index.tsx
+++ b/src/components/User/Register/index.tsx
@@ -39,7 +39,7 @@ const Register: React.FC = () => {
     }
 
     try {
-      const response = await axiosInstance.post('auth/register', {
+      await axiosInstance.post('auth/register', {
         userCiNumber: userInfo.userCiNumber,
         userName: userInfo.userName,
         userPhone: userInfo.userPhone,

--- a/src/components/User/UserLog/PointLogItem/index.tsx
+++ b/src/components/User/UserLog/PointLogItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import * as _ from './style';
 import { useAuth } from 'contexts/authContext';
 import RefundFormModal from './RefundFormModal';

--- a/src/components/User/UserLog/index.jsx
+++ b/src/components/User/UserLog/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import Icon from 'components/Icon';
 import { axiosInstance } from 'utils/Axios';
 import { useSwipeable } from 'react-swipeable';

--- a/src/components/User/UserMain/Notice/NoticeList.tsx
+++ b/src/components/User/UserMain/Notice/NoticeList.tsx
@@ -16,7 +16,7 @@ const NoticeList: React.FC = () => {
       try {
         const fetchedNotices = await fetchNotices();
         setNotices(fetchedNotices);
-      } catch (err) {
+      } catch (_err) {
         setError('공지사항을 가져오는 데 실패했습니다.');
       } finally {
         setLoading(false);

--- a/src/components/User/UserMain/index.tsx
+++ b/src/components/User/UserMain/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import * as S from './style';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from 'contexts/authContext';

--- a/src/components/User/UserMain/style.ts
+++ b/src/components/User/UserMain/style.ts
@@ -9,7 +9,6 @@ const sectionCardBackground = '#f8f9fa';
 const sectionCardBorder = '1.5px solid rgba(17, 17, 17, 0.08)';
 const sectionCardRadius = '28px';
 const innerCardBorder = '1.5px solid rgba(17, 17, 17, 0.08)';
-const accentBorder = '1.5px solid rgba(244, 158, 21, 0.35)';
 
 export const MainContent = styled.div`
   width: 100%;

--- a/src/contexts/loadingContext.jsx
+++ b/src/contexts/loadingContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, useEffect, useCallback, useRef } from 'react';
+import { createContext, useState, useContext, useEffect, useCallback, useRef } from 'react';
 import { setLoadingFunction, setErrorFunction } from 'utils/Axios';
 
 const LoadingContext = createContext();

--- a/src/hooks/useBarcode.jsx
+++ b/src/hooks/useBarcode.jsx
@@ -21,7 +21,7 @@ export const useBarcode = () => {
   // console.log("BArcord~")
   const [barcode, setBarcode] = useState('');
 
-  const handleChange = (e) => {
+  const _handleChange = (e) => {
     // console.log(e.target.value);
     setBarcode(e.target.value);
   };
@@ -38,5 +38,5 @@ export const useBarcode = () => {
     }
   };
 
-  return barcode, handleChange, handleSubmit;
+  return barcode, _handleChange, handleSubmit;
 };

--- a/src/pages/Admin/LoginPage/index.jsx
+++ b/src/pages/Admin/LoginPage/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import AdminLogin from 'components/Admin/Auth/AdminLogin';
 
 export default function AdminLoginPage() {

--- a/src/pages/Admin/MainPage/AdminMainHeader/index.jsx
+++ b/src/pages/Admin/MainPage/AdminMainHeader/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from 'contexts/authContext';
 import * as _ from './style';

--- a/src/pages/Admin/MainPage/index.jsx
+++ b/src/pages/Admin/MainPage/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import * as P from 'common/PageWrapStyle';
 import AdminRouter from 'components/Admin/AdminRouter';
 import AdminMainHeader from './AdminMainHeader';

--- a/src/pages/Admin/Preparing.jsx
+++ b/src/pages/Admin/Preparing.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import * as N from '../../common/PageWrapStyle';
 
 export default function Preparing() {

--- a/src/pages/Admin/TablePage/TableHeader.jsx
+++ b/src/pages/Admin/TablePage/TableHeader.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import * as _ from './style';
 import DatePicker from 'react-datepicker';
 import * as xlsx from 'xlsx';

--- a/src/pages/Admin/TablePage/index.jsx
+++ b/src/pages/Admin/TablePage/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import TableHeader from './TableHeader';
 import DataTable from './Table';
 import styled from 'styled-components';

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import * as N from 'common/PageWrapStyle';
 
 export default function NotFoundPage() {

--- a/src/pages/Pg/PaymentRedirect.jsx
+++ b/src/pages/Pg/PaymentRedirect.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import axiosInstance from 'utils/Axios';
 import * as S from './style';

--- a/src/pages/Pg/PaymentResult.jsx
+++ b/src/pages/Pg/PaymentResult.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import * as S from './style';
 

--- a/src/pages/User/UserPage/UserHeader/index.tsx
+++ b/src/pages/User/UserPage/UserHeader/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import * as H from './style';
 import Icon from 'components/Icon';
 import { useAuth } from 'contexts/authContext';

--- a/src/pages/User/UserPage/index.tsx
+++ b/src/pages/User/UserPage/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Outlet } from 'react-router-dom';
 import UserHeader from 'pages/User/UserPage/UserHeader';
 import Footer from 'components/Footer';


### PR DESCRIPTION
## 요약

- Biome lint에서 감지된 unused import/variable을 정리했습니다.

## 목적

- Biome lint warning을 제거해 이후 CI에서 `biome check`를 안정적으로 적용하기 위함입니다.

## 변경 사항

- 사용하지 않는 `React` import 제거
- 사용하지 않는 catch parameter를 `_error` 형태로 정리
- 사용하지 않는 변수/상수 제거

## PR 업로드 전 체크리스트

- [x] `yarn build` 완료
- [x] lint/format 완료
- [ ] 주요 화면 동작 확인
- [ ] 관련 기능 수동 테스트
- [ ] N/A

## 영향 범위

- [ ] UI
- [ ] API 연동
- [ ] 인증/권한
- [ ] 라우팅
- [ ] 상태 관리
- [ ] 성능
- [x] 빌드/설정
- [ ] 문서
- [x] 기타

## 스크린샷 / 화면 녹화

| AS-IS | TO-BE |
| --- | --- |
| N/A | N/A |

## 리뷰 포인트

- 기능 변경 없이 unused import/variable만 정리한 PR입니다.
- `yarn biome check --write --unsafe src` 적용 후, CRA build warning을 없애기 위해 일부 unused 변수는 직접 제거했습니다.

## 후속 작업

- GitHub Actions에 Biome check를 추가할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modernized React imports across components to use the latest JSX runtime standards
  * Cleaned up unused variables and imports throughout the codebase

<!-- end of auto-generated comment: release notes by coderabbit.ai -->