### PR TITLE
fix(occount-app): fix manifest path from occount-front to occount-app

### DIFF
--- a/jenkins/Jenkinsfile.prod
+++ b/jenkins/Jenkinsfile.prod
@@ -79,7 +79,7 @@ pipeline {
                                 git clone ${MANIFEST_REPO} ${manifestDir}
                                 chmod -R a+rw ${manifestDir}
                             """
-                            def valuesPath = "${manifestDir}/helm/occount-front/${VALUES_FILE}"
+                            def valuesPath = "${manifestDir}/helm/occount-app/${VALUES_FILE}"
                             def values = readYaml file: valuesPath
                             if (!values.apps) values.apps = [:]
                             if (!values.apps[YAML_KEY]) values.apps[YAML_KEY] = [image: [:]]
@@ -91,7 +91,7 @@ pipeline {
                                     cd ${manifestDir}
                                     git config user.email "jenkins@devcoop.local"
                                     git config user.name "Jenkins CI"
-                                    git add helm/occount-front/${VALUES_FILE}
+                                    git add helm/occount-app/${VALUES_FILE}
                                     git diff --cached --quiet || git commit -m "${COMMIT_PREFIX}: bump [${YAML_KEY}] to ${env.IMAGE_TAG}"
                                     git pull --rebase ${MANIFEST_REPO} main
                                     git push ${MANIFEST_REPO} HEAD:main


### PR DESCRIPTION
## 요약
- Jenkins 파이프라인의 manifest 업데이트 경로 오류 수정

## 목적
- `helm/occount-front`로 잘못 설정된 경로로 인해 이미지 태그가 업데이트되지 않는 문제 수정

## 변경 사항
- `Jenkinsfile.prod`의 valuesPath 및 git add 경로를 `occount-front` → `occount-app`으로 수정

## PR 업로드 전 체크리스트
- [ ] `yarn build` 완료
- [ ] lint/format 완료
- [ ] 주요 화면 동작 확인
- [ ] 관련 기능 수동 테스트
- [x] N/A

## 영향 범위
- [x] 빌드/설정

## 스크린샷 / 화면 녹화
| AS-IS | TO-BE |
| --- | --- |
| N/A | N/A |

## 리뷰 포인트
- Jenkinsfile.prod 경로 변경이 올바른지 확인

## 후속 작업
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and deployment pipeline configuration to reference updated manifest file locations for application deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->