### PR TITLE
feat: add api client abstraction and migrate item list

### DIFF
--- a/src/api/client/axiosAdapter.ts
+++ b/src/api/client/axiosAdapter.ts
@@ -1,0 +1,150 @@
+import axios, {
+  AxiosError,
+  AxiosHeaders,
+  AxiosRequestConfig,
+  InternalAxiosRequestConfig,
+} from 'axios';
+import { getAccessToken } from 'utils/Axios';
+import { ApiClient, ApiRequestOptions, SetErrorFunction, SetLoadingFunction } from './types';
+
+const currentDomain = window.location.hostname;
+const currentProtocol = window.location.protocol;
+
+let setGlobalLoading: SetLoadingFunction | null = null;
+let setGlobalError: SetErrorFunction | null = null;
+let activeRequestCount = 0;
+
+export const setApiClientLoadingFunction = (setLoadingFn: SetLoadingFunction): void => {
+  setGlobalLoading = setLoadingFn;
+};
+
+export const setApiClientErrorFunction = (setErrorFn: SetErrorFunction): void => {
+  setGlobalError = setErrorFn;
+};
+
+const incrementActiveRequests = () => {
+  activeRequestCount++;
+  if (setGlobalLoading) setGlobalLoading(true);
+};
+
+const decrementActiveRequests = () => {
+  activeRequestCount--;
+  if (activeRequestCount === 0 && setGlobalLoading) {
+    setGlobalLoading(false);
+  }
+};
+
+const getApiV3BaseURL = (): string => {
+  if (process.env.REACT_APP_API_V3_URL) {
+    return process.env.REACT_APP_API_V3_URL;
+  }
+
+  if (process.env.REACT_APP_API_URL) {
+    const apiURL = process.env.REACT_APP_API_URL.replace(/\/$/, '');
+    return apiURL.endsWith('/api/v3') || apiURL.endsWith('/v3') ? apiURL : `${apiURL}/v3`;
+  }
+
+  return `${currentProtocol}//${currentDomain}/api/v3`;
+};
+
+const axiosClient = axios.create({
+  baseURL: getApiV3BaseURL(),
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+axiosClient.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    incrementActiveRequests();
+
+    const token = getAccessToken();
+    if (token) {
+      if (config.headers instanceof AxiosHeaders) {
+        config.headers.set('Authorization', `Bearer ${token}`);
+      } else {
+        config.headers = new AxiosHeaders({
+          Authorization: `Bearer ${token}`,
+          ...((config.headers as Record<string, string>) || {}),
+        });
+      }
+    }
+
+    return config;
+  },
+  (error: AxiosError) => {
+    decrementActiveRequests();
+    return Promise.reject(error);
+  }
+);
+
+axiosClient.interceptors.response.use(
+  (response) => {
+    decrementActiveRequests();
+    if (setGlobalError) setGlobalError(null);
+    return response;
+  },
+  async (error: AxiosError) => {
+    decrementActiveRequests();
+
+    const config = error.config as AxiosRequestConfig & ApiRequestOptions;
+    if (!config?.skipGlobalError && setGlobalError) {
+      setGlobalError(error);
+    }
+
+    if (error.response?.status === 401) {
+      if (config?.skipAuthRedirect) {
+        return Promise.reject(error);
+      }
+
+      try {
+        sessionStorage.clear();
+        window.location.href = '/login';
+      } catch (logoutError) {
+        console.error('로그아웃 처리 중 오류 발생:', logoutError);
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+const buildConfig = (options?: ApiRequestOptions): AxiosRequestConfig & ApiRequestOptions => {
+  return {
+    headers: options?.headers,
+    params: options?.searchParams,
+    skipGlobalError: options?.skipGlobalError,
+    skipAuthRedirect: options?.skipAuthRedirect,
+  };
+};
+
+export const apiClient: ApiClient = {
+  get: async <T>(path: string, options?: ApiRequestOptions): Promise<T> => {
+    const response = await axiosClient.get<T>(path, buildConfig(options));
+    return response.data;
+  },
+
+  post: async <T, B = unknown>(path: string, body?: B, options?: ApiRequestOptions): Promise<T> => {
+    const response = await axiosClient.post<T>(path, body, buildConfig(options));
+    return response.data;
+  },
+
+  put: async <T, B = unknown>(path: string, body?: B, options?: ApiRequestOptions): Promise<T> => {
+    const response = await axiosClient.put<T>(path, body, buildConfig(options));
+    return response.data;
+  },
+
+  patch: async <T, B = unknown>(
+    path: string,
+    body?: B,
+    options?: ApiRequestOptions
+  ): Promise<T> => {
+    const response = await axiosClient.patch<T>(path, body, buildConfig(options));
+    return response.data;
+  },
+
+  delete: async <T>(path: string, options?: ApiRequestOptions): Promise<T> => {
+    const response = await axiosClient.delete<T>(path, buildConfig(options));
+    return response.data;
+  },
+};

--- a/src/api/client/index.ts
+++ b/src/api/client/index.ts
@@ -1,0 +1,2 @@
+export { apiClient, setApiClientErrorFunction, setApiClientLoadingFunction } from './axiosAdapter';
+export type { ApiClient, ApiRequestOptions } from './types';

--- a/src/api/client/types.ts
+++ b/src/api/client/types.ts
@@ -1,0 +1,17 @@
+export type ApiRequestOptions = {
+  headers?: Record<string, string>;
+  searchParams?: Record<string, string | number | boolean | null | undefined>;
+  skipGlobalError?: boolean;
+  skipAuthRedirect?: boolean;
+};
+
+export type ApiClient = {
+  get: <T>(path: string, options?: ApiRequestOptions) => Promise<T>;
+  post: <T, B = unknown>(path: string, body?: B, options?: ApiRequestOptions) => Promise<T>;
+  put: <T, B = unknown>(path: string, body?: B, options?: ApiRequestOptions) => Promise<T>;
+  patch: <T, B = unknown>(path: string, body?: B, options?: ApiRequestOptions) => Promise<T>;
+  delete: <T>(path: string, options?: ApiRequestOptions) => Promise<T>;
+};
+
+export type SetLoadingFunction = (isLoading: boolean) => void;
+export type SetErrorFunction = (error: unknown) => void;

--- a/src/components/User/ItemList/index.tsx
+++ b/src/components/User/ItemList/index.tsx
@@ -1,105 +1,21 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import * as S from './style';
+import React from 'react';
+import * as ItemListStyles from './style';
 import { ContentContainer } from 'common/ContentContainer';
 import Icon from 'components/Icon';
-import axiosInstance from 'utils/Axios';
-import { mockProducts } from 'components/User/UserMain/mockData';
-
-interface Item {
-  itemId: number;
-  itemName: string;
-  itemCode: string;
-  itemPrice: number;
-  category?: string;
-  isNew?: boolean;
-  isHot?: boolean;
-}
-
-const fallbackItems: Item[] = mockProducts.map((product) => ({
-  itemId: product.id,
-  itemName: product.title,
-  itemCode: `MOCK-${product.id}`,
-  itemPrice: product.price ?? 0,
-  category: product.category,
-  isNew: product.badge === 'new',
-  isHot: product.badge === 'hot',
-}));
-
-const categories = ['전체보기', '과자', '아이스크림', '음료', '냉동식품', '빵류', '식품', '잡화'];
+import { categories, useItemList } from './useItemList';
 
 const ItemList: React.FC = () => {
-  const [items, setItems] = useState<Item[]>([]);
-  const [filteredItems, setFilteredItems] = useState<Item[]>([]);
-  const [selectedCategory, setSelectedCategory] = useState<string>('전체보기');
-  const [searchTerm, setSearchTerm] = useState<string>('');
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const filterItems = useCallback(() => {
-    let filtered = items;
-
-    // 카테고리 필터
-    if (selectedCategory !== '전체보기') {
-      filtered = filtered.filter((item) => item.category === selectedCategory);
-    }
-
-    // 검색어 필터
-    if (searchTerm.trim() !== '') {
-      filtered = filtered.filter((item) =>
-        item.itemName.toLowerCase().includes(searchTerm.toLowerCase())
-      );
-    }
-
-    setFilteredItems(filtered);
-  }, [items, selectedCategory, searchTerm]);
-
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
-
-  useEffect(() => {
-    fetchItems();
-  }, []);
-
-  useEffect(() => {
-    filterItems();
-  }, [filterItems]);
-
-  const fetchItems = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const response = await axiosInstance.get('v2/item/');
-
-      if (
-        response.status === 204 ||
-        !response.data.itemList ||
-        response.data.itemList.length === 0
-      ) {
-        setItems([]);
-        setFilteredItems([]);
-      } else {
-        const remappedData: Item[] = response.data.itemList.map((item: any) => ({
-          itemId: item.itemId,
-          itemName: item.itemName,
-          itemCode: item.itemCode,
-          itemPrice: item.itemPrice,
-          category: item.category || '기타',
-          isNew: item.isNew || false,
-          isHot: item.isHot || false,
-        }));
-        setItems(remappedData);
-        setFilteredItems(remappedData);
-      }
-    } catch (error) {
-      console.error('Error fetching items:', error);
-      setItems(fallbackItems);
-      setFilteredItems(fallbackItems);
-      setError('상품 목록을 불러오지 못해 임시 목록을 표시하고 있습니다.');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const {
+    filteredItems,
+    selectedCategory,
+    searchTerm,
+    loading,
+    error,
+    hasItems,
+    isEmpty,
+    setSelectedCategory,
+    setSearchTerm,
+  } = useItemList();
 
   const handleCategoryClick = (category: string) => {
     setSelectedCategory(category);
@@ -111,54 +27,58 @@ const ItemList: React.FC = () => {
 
   return (
     <ContentContainer>
-      <S.Title>상품 목록</S.Title>
+      <ItemListStyles.Title>상품 목록</ItemListStyles.Title>
 
-      <S.FilterSection>
-        <S.CategoryTabBar>
+      <ItemListStyles.FilterSection>
+        <ItemListStyles.CategoryTabBar>
           {categories.map((category) => (
-            <S.CategoryTab
+            <ItemListStyles.CategoryTab
               key={category}
               $active={selectedCategory === category}
               onClick={() => handleCategoryClick(category)}
             >
               {category}
-            </S.CategoryTab>
+            </ItemListStyles.CategoryTab>
           ))}
-        </S.CategoryTabBar>
+        </ItemListStyles.CategoryTabBar>
 
-        <S.SearchBar>
-          <S.SearchInput
+        <ItemListStyles.SearchBar>
+          <ItemListStyles.SearchInput
             type="text"
             placeholder="찾으시는 상품을 입력해주세요"
             value={searchTerm}
             onChange={handleSearchChange}
           />
-          <S.SearchIcon>
+          <ItemListStyles.SearchIcon>
             <Icon name="search" size={22} color="#F49E15" strokeWidth={2} />
-          </S.SearchIcon>
-        </S.SearchBar>
-      </S.FilterSection>
+          </ItemListStyles.SearchIcon>
+        </ItemListStyles.SearchBar>
+      </ItemListStyles.FilterSection>
 
-      {error && <S.WarningMessage>{error}</S.WarningMessage>}
+      {error && <ItemListStyles.WarningMessage>{error}</ItemListStyles.WarningMessage>}
 
-      {loading ? (
-        <S.LoadingMessage>로딩 중...</S.LoadingMessage>
-      ) : filteredItems.length === 0 ? (
-        <S.EmptyMessage>상품이 없습니다.</S.EmptyMessage>
-      ) : (
-        <S.ProductGrid>
+      {loading && <ItemListStyles.LoadingMessage>로딩 중...</ItemListStyles.LoadingMessage>}
+
+      {isEmpty && <ItemListStyles.EmptyMessage>상품이 없습니다.</ItemListStyles.EmptyMessage>}
+
+      {hasItems && (
+        <ItemListStyles.ProductGrid>
           {filteredItems.map((item) => (
-            <S.ProductCard key={item.itemId}>
-              <S.ProductInfo>
+            <ItemListStyles.ProductCard key={item.itemId}>
+              <ItemListStyles.ProductInfo>
                 {(item.isNew || item.isHot) && (
-                  <S.Badge type={item.isNew ? 'new' : 'hot'}>{item.isNew ? 'NEW' : 'HOT'}</S.Badge>
+                  <ItemListStyles.Badge type={item.isNew ? 'new' : 'hot'}>
+                    {item.isNew ? 'NEW' : 'HOT'}
+                  </ItemListStyles.Badge>
                 )}
-                <S.ProductTitle>{item.itemName}</S.ProductTitle>
-                <S.ProductPrice>{item.itemPrice.toLocaleString()} 원</S.ProductPrice>
-              </S.ProductInfo>
-            </S.ProductCard>
+                <ItemListStyles.ProductTitle>{item.itemName}</ItemListStyles.ProductTitle>
+                <ItemListStyles.ProductPrice>
+                  {item.itemPrice.toLocaleString()} 원
+                </ItemListStyles.ProductPrice>
+              </ItemListStyles.ProductInfo>
+            </ItemListStyles.ProductCard>
           ))}
-        </S.ProductGrid>
+        </ItemListStyles.ProductGrid>
       )}
     </ContentContainer>
   );

--- a/src/components/User/ItemList/itemListApi.ts
+++ b/src/components/User/ItemList/itemListApi.ts
@@ -1,0 +1,39 @@
+import { apiClient } from 'api/client';
+
+export interface Item {
+  itemId: number;
+  itemName: string;
+  itemCode: string;
+  itemPrice: number;
+  category?: string;
+  isNew?: boolean;
+  isHot?: boolean;
+}
+
+interface ApiItem {
+  itemId: number;
+  name: string;
+  category?: string;
+  price: number;
+  quantity: number;
+  barcode?: string | null;
+}
+
+interface ItemListResponse {
+  items: ApiItem[];
+}
+
+const mapApiItemToItem = (item: ApiItem): Item => ({
+  itemId: item.itemId,
+  itemName: item.name,
+  itemCode: item.barcode ?? `ITEM-${item.itemId}`,
+  itemPrice: item.price,
+  category: item.category || '기타',
+  isNew: false,
+  isHot: false,
+});
+
+export const fetchItemList = async (): Promise<Item[]> => {
+  const response = await apiClient.get<ItemListResponse>('items');
+  return response.items?.map(mapApiItemToItem) ?? [];
+};

--- a/src/components/User/ItemList/useItemList.ts
+++ b/src/components/User/ItemList/useItemList.ts
@@ -1,0 +1,82 @@
+import { useEffect, useMemo, useState } from 'react';
+import { mockProducts } from 'components/User/UserMain/mockData';
+import { fetchItemList, Item } from './itemListApi';
+
+export const categories = [
+  '전체보기',
+  '과자',
+  '아이스크림',
+  '음료',
+  '냉동식품',
+  '빵류',
+  '식품',
+  '잡화',
+];
+
+const fallbackItems: Item[] = mockProducts.map((product) => ({
+  itemId: product.id,
+  itemName: product.title,
+  itemCode: `MOCK-${product.id}`,
+  itemPrice: product.price ?? 0,
+  category: product.category,
+  isNew: product.badge === 'new',
+  isHot: product.badge === 'hot',
+}));
+
+const filterItemList = (items: Item[], selectedCategory: string, searchTerm: string): Item[] => {
+  const normalizedSearchTerm = searchTerm.trim().toLowerCase();
+
+  return items.filter((item) => {
+    const matchesCategory = selectedCategory === '전체보기' || item.category === selectedCategory;
+    const matchesSearchTerm =
+      normalizedSearchTerm === '' || item.itemName.toLowerCase().includes(normalizedSearchTerm);
+
+    return matchesCategory && matchesSearchTerm;
+  });
+};
+
+export const useItemList = () => {
+  const [items, setItems] = useState<Item[]>([]);
+  const [selectedCategory, setSelectedCategory] = useState<string>('전체보기');
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const filteredItems = useMemo(
+    () => filterItemList(items, selectedCategory, searchTerm),
+    [items, selectedCategory, searchTerm]
+  );
+
+  const hasItems = filteredItems.length > 0;
+  const isEmpty = !loading && !hasItems;
+
+  useEffect(() => {
+    const loadItems = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        setItems(await fetchItemList());
+      } catch (error) {
+        console.error('Error fetching items:', error);
+        setItems(fallbackItems);
+        setError('상품 목록을 불러오지 못해 임시 목록을 표시하고 있습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadItems();
+  }, []);
+
+  return {
+    filteredItems,
+    selectedCategory,
+    searchTerm,
+    loading,
+    error,
+    hasItems,
+    isEmpty,
+    setSelectedCategory,
+    setSearchTerm,
+  };
+};

--- a/src/contexts/loadingContext.jsx
+++ b/src/contexts/loadingContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useState, useContext, useEffect, useCallback, useRef } from 'react';
 import { setLoadingFunction, setErrorFunction } from 'utils/Axios';
+import { setApiClientLoadingFunction, setApiClientErrorFunction } from 'api/client';
 
 const LoadingContext = createContext();
 
@@ -57,6 +58,8 @@ export const LoadingProvider = ({ children }) => {
   useEffect(() => {
     setLoadingFunction(setLoading);
     setErrorFunction(setError);
+    setApiClientLoadingFunction(setLoading);
+    setApiClientErrorFunction(setError);
 
     return clearAll;
   }, [setLoading, setError, clearAll]);


### PR DESCRIPTION
## 요약

- v3 API 호출을 위한 `apiClient` 추상화를 추가하고, 사용자 상품 목록을 `/api/v3/items` 기반으로 이관했습니다.

## 목적

- 기존 `axiosInstance`에 직접 의존하지 않는 API client 경계를 만들어 이후 Fetch 전환 시 adapter만 교체할 수 있도록 하기 위함입니다.
- 서버 v3 API가 구현된 상품 목록부터 점진적으로 이관하기 위함입니다.

## 변경 사항

- `src/api/client` 추가
  - 외부 호출부에는 axios 응답 객체를 노출하지 않고 data만 반환
  - 현재 내부 구현은 axios adapter 사용
  - 추후 fetch adapter로 교체 가능한 구조
- `ItemList` 상품 목록 조회를 `v2/item/`에서 v3 `items` 호출로 변경
- v3 item 응답을 화면 모델로 변환하는 `itemListApi.ts` 추가
- 상품 목록 상태/필터링 로직을 `useItemList.ts`로 정리
- `ItemList` 스타일 namespace를 `S`에서 `ItemListStyles`로 명시화
- 기존처럼 전체 상품 목록 조회 후 클라이언트에서 검색/카테고리 필터링 유지

## PR 업로드 전 체크리스트

- [x] `yarn build` 완료
- [x] lint/format 완료
- [ ] 주요 화면 동작 확인
- [ ] 관련 기능 수동 테스트
- [ ] N/A

## 영향 범위

- [x] UI
- [x] API 연동
- [ ] 인증/권한
- [ ] 라우팅
- [x] 상태 관리
- [ ] 성능
- [ ] 빌드/설정
- [ ] 문서
- [ ] 기타

## 스크린샷 / 화면 녹화

| AS-IS | TO-BE |
| --- | --- |
| N/A | <img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/35f9e0d9-f785-4094-aecf-4c7a537fc073" /> |

## 리뷰 포인트

- `apiClient`는 현재 axios 기반이지만 호출부에 axios 타입을 노출하지 않도록 구성했습니다.
- 검색은 아직 서버 검색 API(`/api/v3/items/search`)를 사용하지 않고, 기존 동작과 동일하게 클라이언트 필터링을 유지했습니다.
- 상품 이미지는 기존 UI와 v3 응답 모두에 없어 이번 작업 범위에 포함하지 않았습니다.

## 후속 작업

- TanStack Query 도입 검토
- 서버 검색 API(`/api/v3/items/search`) 연동 및 debounce 처리
- 다른 v3 확정 API의 점진 이관


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the item list component's architecture for improved separation of concerns and maintainability.
  * Modularized API client infrastructure with centralized request/response handling, token management, and error handling.

* **Chores**
  * Reorganized code structure to improve scalability and code reusability across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->