### PR TITLE
feat: 홈화면 상품 섹션 API 연동

### DIFF
--- a/src/components/User/UserMain/index.tsx
+++ b/src/components/User/UserMain/index.tsx
@@ -118,7 +118,9 @@ function Main() {
       }
     };
     loadProducts();
-    return () => { mounted = false; };
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   useEffect(() => {
@@ -334,12 +336,8 @@ function Main() {
                 <S.ProductCardRow key={rowIndex}>
                   {row.map((product) => (
                     <S.ProductCard key={product.itemId}>
-                      {product.isNew && (
-                        <S.ProductBadge type="new">NEW</S.ProductBadge>
-                      )}
-                      {product.isHot && (
-                        <S.ProductBadge type="hot">HOT</S.ProductBadge>
-                      )}
+                      {product.isNew && <S.ProductBadge type="new">NEW</S.ProductBadge>}
+                      {product.isHot && <S.ProductBadge type="hot">HOT</S.ProductBadge>}
                       <S.ProductInfo>
                         <h3>{product.itemName}</h3>
                         <div className="price">

--- a/src/components/User/UserMain/index.tsx
+++ b/src/components/User/UserMain/index.tsx
@@ -105,16 +105,20 @@ function Main() {
   useEffect(() => {
     if (USE_MOCK_DATA) {
       setProducts(fallbackProducts);
-    } else {
-      const loadProducts = async () => {
-        try {
-          setProducts(await fetchItemList());
-        } catch {
-          setProducts(fallbackProducts);
-        }
-      };
-      loadProducts();
+      return;
     }
+
+    let mounted = true;
+    const loadProducts = async () => {
+      try {
+        const fetched = await fetchItemList();
+        if (mounted) setProducts(fetched);
+      } catch {
+        if (mounted) setProducts(fallbackProducts);
+      }
+    };
+    loadProducts();
+    return () => { mounted = false; };
   }, []);
 
   useEffect(() => {
@@ -330,10 +334,11 @@ function Main() {
                 <S.ProductCardRow key={rowIndex}>
                   {row.map((product) => (
                     <S.ProductCard key={product.itemId}>
-                      {(product.isNew || product.isHot) && (
-                        <S.ProductBadge type={product.isNew ? 'new' : 'hot'}>
-                          {product.isNew ? 'NEW' : 'HOT'}
-                        </S.ProductBadge>
+                      {product.isNew && (
+                        <S.ProductBadge type="new">NEW</S.ProductBadge>
+                      )}
+                      {product.isHot && (
+                        <S.ProductBadge type="hot">HOT</S.ProductBadge>
                       )}
                       <S.ProductInfo>
                         <h3>{product.itemName}</h3>

--- a/src/components/User/UserMain/index.tsx
+++ b/src/components/User/UserMain/index.tsx
@@ -9,7 +9,18 @@ import Barcode from 'react-barcode';
 import Toast from 'common/Toast';
 import Icon from 'components/Icon';
 import { fetchNotices, Notice as ApiNotice } from './Notice/notices';
-import { mockAnnouncements, mockNotices, mockProducts, NoticeItem, Product } from './mockData';
+import { mockAnnouncements, mockNotices, mockProducts, NoticeItem } from './mockData';
+import { fetchItemList, Item } from 'components/User/ItemList/itemListApi';
+
+const fallbackProducts: Item[] = mockProducts.map((p) => ({
+  itemId: p.id,
+  itemName: p.title,
+  itemCode: `MOCK-${p.id}`,
+  itemPrice: p.price ?? 0,
+  category: p.category,
+  isNew: p.badge === 'new',
+  isHot: p.badge === 'hot',
+}));
 
 interface User {
   point: number;
@@ -31,7 +42,7 @@ function Main() {
   const [isInquiryModalOpen, setIsInquiryModalOpen] = useState<boolean>(false);
   const [showInvestmentModal, setShowInvestmentModal] = useState<boolean>(false);
   const [selectedCategory, setSelectedCategory] = useState<string>('전체보기');
-  const [products, setProducts] = useState<Product[]>(mockProducts);
+  const [products, setProducts] = useState<Item[]>([]);
   const [allNotices, setAllNotices] = useState<NoticeItem[]>([]);
   const [showLoginToast, setShowLoginToast] = useState<boolean>(false);
 
@@ -93,7 +104,21 @@ function Main() {
 
   useEffect(() => {
     if (USE_MOCK_DATA) {
-      setProducts(mockProducts);
+      setProducts(fallbackProducts);
+    } else {
+      const loadProducts = async () => {
+        try {
+          setProducts(await fetchItemList());
+        } catch {
+          setProducts(fallbackProducts);
+        }
+      };
+      loadProducts();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (USE_MOCK_DATA) {
       // 모든 공지사항을 하나로 통합 (중요도 높은 것부터 표시)
       const combinedNotices = [...mockNotices, ...mockAnnouncements].sort((a, b) => {
         // 중요도가 높은 것 먼저, 그 다음 최신순
@@ -150,7 +175,7 @@ function Main() {
   }, [products, selectedCategory]);
 
   const productRows = useMemo(() => {
-    const rows: Product[][] = [];
+    const rows: Item[][] = [];
     for (let i = 0; i < filteredProducts.length; i += 2) {
       rows.push(filteredProducts.slice(i, i + 2));
     }
@@ -304,21 +329,17 @@ function Main() {
               productRows.map((row, rowIndex) => (
                 <S.ProductCardRow key={rowIndex}>
                   {row.map((product) => (
-                    <S.ProductCard key={product.id}>
-                      {product.badge && (
-                        <S.ProductBadge type={product.badge}>
-                          {product.badge === 'new' ? 'NEW' : 'HOT'}
+                    <S.ProductCard key={product.itemId}>
+                      {(product.isNew || product.isHot) && (
+                        <S.ProductBadge type={product.isNew ? 'new' : 'hot'}>
+                          {product.isNew ? 'NEW' : 'HOT'}
                         </S.ProductBadge>
                       )}
                       <S.ProductInfo>
-                        <h3>{product.title}</h3>
+                        <h3>{product.itemName}</h3>
                         <div className="price">
-                          <span>
-                            {product.price !== undefined
-                              ? product.price.toLocaleString()
-                              : '가격 정보 없음'}
-                          </span>
-                          {product.price !== undefined && <span>원</span>}
+                          <span>{product.itemPrice.toLocaleString()}</span>
+                          <span>원</span>
                         </div>
                       </S.ProductInfo>
                     </S.ProductCard>


### PR DESCRIPTION
## Summary

- 홈화면 '매점상품 보기' 섹션의 상품 데이터를 하드코딩된 목데이터에서 `fetchItemList()` API 호출로 교체
- API 실패 시 기존 `mockProducts` 기반의 `fallbackProducts`로 자동 대체
- `Product` 타입 대신 `Item` 타입 통일로 `/item-list` 페이지와 동일한 데이터 구조 사용

## Test plan

- [ ] 홈화면 접속 시 상품 목록이 API에서 정상적으로 로드되는지 확인
- [ ] API 실패 상황에서 fallback 목데이터가 표시되는지 확인
- [ ] 카테고리 탭 필터링 정상 동작 확인
- [ ] NEW/HOT 배지 렌더링 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the “매점상품 보기” product flow to use live item data (with normalized item details) instead of the prior product/mocked structure, improving consistency in how badges and prices are shown.
* **Bug Fixes**
  * Improved product loading reliability by providing fallback results when live data cannot be retrieved, so the grid remains populated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->