### PR TITLE
fix: PIN 변경 섹션 인증 안내 문구 명확화

### DIFF
--- a/src/components/User/Update/components/PinChangeSection.tsx
+++ b/src/components/User/Update/components/PinChangeSection.tsx
@@ -26,13 +26,13 @@ export const PinChangeSection: React.FC<PinChangeSectionProps> = ({ pinChange })
   if (state.step === 'passwordRequired') {
     return (
       <S.InputContainer>
-        <S.InputLabel>현재 비밀번호</S.InputLabel>
+        <S.InputLabel>오카운트 계정 PW로 인증해 주세요 (PIN 번호 X)</S.InputLabel>
         <S.AuthContainer>
           <S.RegisterInput
             type="password"
             value={state.password}
             onChange={handlePasswordChange}
-            placeholder="현재 비밀번호"
+            placeholder="계정 비밀번호 입력"
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 e.preventDefault();


### PR DESCRIPTION
## Summary
- PIN 변경 시 계정 비밀번호 인증 입력란의 레이블이 '현재 비밀번호'로만 표시되어 PIN인지 계정 PW인지 혼동 유발
- 레이블을 '오카운트 계정 PW로 인증해 주세요 (PIN 번호 X)'로 변경
- placeholder도 '계정 비밀번호 입력'으로 구체화

## Test plan
- [ ] 보안 설정 카드 > PIN 변경 섹션 진입 시 안내 문구 확인
- [ ] 계정 비밀번호 입력 후 정상 인증되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clarity in the account PIN change flow by updating instructional text to specify that users should enter their account password rather than the PIN.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->