### PR TITLE
feat: PIN 변경 인증 유효 시간 카운트다운 추가

### DIFF
--- a/src/components/User/Update/components/PinChangeSection.tsx
+++ b/src/components/User/Update/components/PinChangeSection.tsx
@@ -12,6 +12,8 @@ export const PinChangeSection: React.FC<PinChangeSectionProps> = ({ pinChange })
     isLoading,
     pinWarning,
     confirmWarning,
+    remainingSeconds,
+    formatTime,
     handlePasswordChange,
     handleVerifyPassword,
     handlePinChange,
@@ -52,6 +54,9 @@ export const PinChangeSection: React.FC<PinChangeSectionProps> = ({ pinChange })
   // step === 'passwordVerified'
   return (
     <>
+      <S.ExpiryTimer>
+        인증 유효 시간: <span>{formatTime(remainingSeconds)}</span>
+      </S.ExpiryTimer>
       <S.InputContainer>
         <S.InputLabel>새 PIN</S.InputLabel>
         <S.RegisterInput

--- a/src/components/User/Update/hooks/usePinChange.ts
+++ b/src/components/User/Update/hooks/usePinChange.ts
@@ -1,4 +1,4 @@
-import { useState, type ChangeEvent } from 'react';
+import { useState, useEffect, useRef, type ChangeEvent } from 'react';
 import axiosInstance from 'utils/Axios';
 import { VALIDATION_PATTERNS } from '../constants/validation';
 import { UPDATE_MESSAGES } from '../constants/messages';
@@ -17,6 +17,12 @@ type PinChangeState =
     }
   | { step: 'success' };
 
+const formatTime = (seconds: number): string => {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+};
+
 export const usePinChange = () => {
   const [state, setState] = useState<PinChangeState>({
     step: 'passwordRequired',
@@ -26,6 +32,38 @@ export const usePinChange = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [pinWarning, setPinWarning] = useState('');
   const [confirmWarning, setConfirmWarning] = useState('');
+  const [remainingSeconds, setRemainingSeconds] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const startTimer = (seconds: number) => {
+    clearTimer();
+    setRemainingSeconds(seconds);
+    timerRef.current = setInterval(() => {
+      setRemainingSeconds((prev) => {
+        if (prev <= 1) {
+          clearTimer();
+          setState({
+            step: 'passwordRequired',
+            password: '',
+            error: '인증 시간이 만료되었습니다. 다시 시도해주세요.',
+          });
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  useEffect(() => {
+    return () => clearTimer();
+  }, []);
 
   const handlePasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (state.step !== 'passwordRequired') return;
@@ -43,6 +81,7 @@ export const usePinChange = () => {
       const response = await axiosInstance.post('/users/pin/change-ticket', {
         password: state.password,
       });
+      startTimer(response.data.expires_in);
       setState({
         step: 'passwordVerified',
         ticket: response.data.ticket,
@@ -93,6 +132,7 @@ export const usePinChange = () => {
         ticket: state.ticket,
         new_pin: state.newPin,
       });
+      clearTimer();
       setState({ step: 'success' });
     } catch (error: any) {
       setState({
@@ -109,6 +149,8 @@ export const usePinChange = () => {
     isLoading,
     pinWarning,
     confirmWarning,
+    remainingSeconds,
+    formatTime,
     handlePasswordChange,
     handleVerifyPassword,
     handlePinChange,

--- a/src/components/User/Update/style.ts
+++ b/src/components/User/Update/style.ts
@@ -485,3 +485,15 @@ export const WarningMessage = styled.p`
   margin: 8px 0 0;
   font-family: "Pretendard", sans-serif;
 `;
+
+export const ExpiryTimer = styled.p`
+  color: #1a6fc4;
+  font-size: 12px;
+  font-family: "Pretendard", sans-serif;
+  margin: 0 0 4px;
+
+  span {
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+  }
+`;


### PR DESCRIPTION
## Summary

- `POST /users/pin/change-ticket` 응답의 `expires_in` 값을 활용해 카운트다운 타이머 구현
- 비밀번호 인증 완료 후 `인증 유효 시간: MM:SS` 형식으로 UI에 표시
- 타이머 만료 시 자동으로 비밀번호 입력 단계로 복귀하며 안내 메시지 표시
- PIN 변경 성공(204 응답) 및 컴포넌트 언마운트 시 타이머 정리

## Changes

- `usePinChange.ts`: `startTimer` / `clearTimer` 추가, `expires_in` 기반 카운트다운, `remainingSeconds` / `formatTime` 반환
- `PinChangeSection.tsx`: `passwordVerified` 단계 상단에 인증 유효 시간 표시
- `style.ts`: `ExpiryTimer` 스타일 컴포넌트 추가

## Test plan

- [ ] 비밀번호 인증 후 카운트다운 타이머가 MM:SS 형식으로 표시되는지 확인
- [ ] 타이머 만료 시 비밀번호 입력 단계로 복귀하고 만료 안내 메시지가 표시되는지 확인
- [ ] PIN 변경 완료 후 성공 메시지가 표시되는지 확인
- [ ] 페이지 이탈 시 타이머가 정리되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)