### PR TITLE
feat: JWT 만료 시 자동 로그아웃 및 로그인 페이지 리다이렉트

### DIFF
--- a/src/contexts/authContext.tsx
+++ b/src/contexts/authContext.tsx
@@ -51,6 +51,28 @@ interface AuthContextType extends AuthState {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+const getTokenExpiry = (token: string): number | null => {
+  try {
+    const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+    const payload = JSON.parse(atob(base64));
+    return typeof payload.exp === 'number' ? payload.exp : null;
+  } catch {
+    return null;
+  }
+};
+
+const isTokenExpired = (token: string): boolean => {
+  const exp = getTokenExpiry(token);
+  if (exp === null) return true;
+  return Date.now() / 1000 >= exp;
+};
+
+const isTokenValid = (): boolean => {
+  const token = getAccessToken();
+  if (!token) return false;
+  return !isTokenExpired(token);
+};
+
 // 개발 모드용 Mock 사용자 데이터
 const getMockUser = (): User => ({
   point: 100000,
@@ -72,7 +94,7 @@ const createBypassAxios = () => {
 };
 
 const initialState: AuthState = {
-  isLoggedIn: isDevMode() || !!getAccessToken(),
+  isLoggedIn: isDevMode() || isTokenValid(),
   isAdminLoggedIn: !!sessionStorage.getItem('isAdminLoggedIn'),
   user: isDevMode() ? getMockUser() : null,
   errorMessage: '',
@@ -130,7 +152,7 @@ const authReducer = (state: AuthState, action: ActionType): AuthState => {
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [state, dispatch] = useReducer(authReducer, initialState);
-  const [isInitializing, setIsInitializing] = React.useState(!isDevMode() && !!getAccessToken());
+  const [isInitializing, setIsInitializing] = React.useState(!isDevMode() && isTokenValid());
 
   // 컴포넌트 마운트 시 개발 모드 초기화
   useEffect(() => {
@@ -361,6 +383,36 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       });
     }
   }, [state.isLoggedIn, fetchUserInformation]);
+
+  // JWT 만료 시 자동 로그아웃
+  useEffect(() => {
+    if (!state.isLoggedIn || isDevMode()) return;
+
+    const token = getAccessToken();
+    if (!token) return;
+
+    const exp = getTokenExpiry(token);
+    if (exp === null) return;
+
+    const msUntilExpiry = exp * 1000 - Date.now();
+
+    if (msUntilExpiry <= 0) {
+      dispatch({ type: actionTypes.LOGOUT });
+      setAccessToken(null);
+      sessionStorage.clear();
+      window.location.href = '/login';
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      dispatch({ type: actionTypes.LOGOUT });
+      setAccessToken(null);
+      sessionStorage.clear();
+      window.location.href = '/login';
+    }, msUntilExpiry);
+
+    return () => clearTimeout(timer);
+  }, [state.isLoggedIn]);
 
   const contextValue: AuthContextType = {
     ...state,


### PR DESCRIPTION
## Summary

- JWT `exp` 클레임을 파싱해 토큰 만료 여부를 검증하는 유틸 함수 추가 (`getTokenExpiry`, `isTokenExpired`, `isTokenValid`)
- 앱 초기 로드 시 이미 만료된 토큰을 가진 경우 로그인 상태로 간주하지 않도록 `initialState` 수정
- 로그인 성공 시 토큰 만료까지 남은 시간을 계산해 `setTimeout`으로 자동 로그아웃 처리 — 만료 시점에 세션 정리 후 `/login` 리다이렉트

## Changes

- `src/contexts/authContext.tsx`
  - `getTokenExpiry` / `isTokenExpired` / `isTokenValid` 유틸 함수 추가
  - `initialState.isLoggedIn`: `!!getAccessToken()` → `isTokenValid()`
  - `isInitializing` 초기값: `!!getAccessToken()` → `isTokenValid()`
  - JWT 만료 자동 로그아웃 `useEffect` 추가

## Test plan

- [ ] 유효한 토큰으로 로그인 후 정상 이용 확인
- [ ] 만료된 토큰을 sessionStorage에 직접 심은 뒤 새로고침 → 로그인 페이지로 이동하는지 확인
- [ ] 토큰 만료 시각 도달 시 자동으로 `/login` 리다이렉트되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)