### PR TITLE
fix: PIN 변경 버튼 유효성 검사 미충족 시 비활성화

### DIFF
--- a/src/components/User/Update/components/PinChangeSection.tsx
+++ b/src/components/User/Update/components/PinChangeSection.tsx
@@ -83,7 +83,11 @@ export const PinChangeSection: React.FC<PinChangeSectionProps> = ({ pinChange })
         {confirmWarning && <S.WarningMessage>{confirmWarning}</S.WarningMessage>}
       </S.InputContainer>
       {state.error && <S.WarningMessage>{state.error}</S.WarningMessage>}
-      <S.SectionSubmitButton type="button" onClick={handleSubmit} disabled={isLoading || isSubmitDisabled}>
+      <S.SectionSubmitButton
+        type="button"
+        onClick={handleSubmit}
+        disabled={isLoading || isSubmitDisabled}
+      >
         {isLoading ? '변경 중...' : 'PIN 변경'}
       </S.SectionSubmitButton>
     </>

--- a/src/components/User/Update/components/PinChangeSection.tsx
+++ b/src/components/User/Update/components/PinChangeSection.tsx
@@ -10,6 +10,7 @@ export const PinChangeSection: React.FC<PinChangeSectionProps> = ({ pinChange })
   const {
     state,
     isLoading,
+    isSubmitDisabled,
     pinWarning,
     confirmWarning,
     remainingSeconds,
@@ -82,7 +83,7 @@ export const PinChangeSection: React.FC<PinChangeSectionProps> = ({ pinChange })
         {confirmWarning && <S.WarningMessage>{confirmWarning}</S.WarningMessage>}
       </S.InputContainer>
       {state.error && <S.WarningMessage>{state.error}</S.WarningMessage>}
-      <S.SectionSubmitButton type="button" onClick={handleSubmit} disabled={isLoading}>
+      <S.SectionSubmitButton type="button" onClick={handleSubmit} disabled={isLoading || isSubmitDisabled}>
         {isLoading ? '변경 중...' : 'PIN 변경'}
       </S.SectionSubmitButton>
     </>

--- a/src/components/User/Update/hooks/usePinChange.ts
+++ b/src/components/User/Update/hooks/usePinChange.ts
@@ -144,9 +144,15 @@ export const usePinChange = () => {
     }
   };
 
+  const isSubmitDisabled =
+    state.step !== 'passwordVerified' ||
+    !VALIDATION_PATTERNS.PIN.test(state.newPin) ||
+    state.newPin !== state.confirmNewPin;
+
   return {
     state,
     isLoading,
+    isSubmitDisabled,
     pinWarning,
     confirmWarning,
     remainingSeconds,


### PR DESCRIPTION
## Summary

- `usePinChange` 훅에 `isSubmitDisabled` 파생값 추가
- PIN이 4~6자리 숫자 조건을 만족하지 않거나, 확인 PIN과 불일치할 경우 버튼 비활성화
- `PinChangeSection` 컴포넌트 버튼의 `disabled` 조건에 `isSubmitDisabled` 적용

## Test plan

- [ ] PIN 미입력 상태에서 버튼 비활성화 확인
- [ ] 3자리 이하 입력 시 버튼 비활성화 확인
- [ ] 4~6자리 입력 후 확인 PIN 불일치 시 버튼 비활성화 확인
- [ ] 4~6자리 입력 + 확인 PIN 일치 시 버튼 활성화 확인
- [ ] PIN 변경 정상 제출 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced PIN change form validation. The submit button is now disabled until all validation requirements are met, including password verification, valid PIN format, and matching PIN confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->