### PR TITLE
feat: 비밀번호 찾기 v3 API 연동 (OTP 방식)

### DIFF
--- a/src/components/User/pwChange/index.jsx
+++ b/src/components/User/pwChange/index.jsx
@@ -1,74 +1,103 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAuth } from 'contexts/authContext';
+import { axiosInstance } from 'utils/Axios';
 import Toast from 'common/Toast';
 import * as L from './style';
 
+const STEP = {
+  EMAIL: 'EMAIL',
+  OTP: 'OTP',
+  SUCCESS: 'SUCCESS',
+};
+
 function PwChange() {
   const navigate = useNavigate();
-  const { requestEmailVerification } = useAuth();
 
+  const [step, setStep] = useState(STEP.EMAIL);
   const [email, setEmail] = useState('');
-  const [name, setName] = useState('');
+  const [otpCode, setOtpCode] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   const [showToast, setShowToast] = useState(false);
   const [toastType, setToastType] = useState('error');
   const [toastMessage, setToastMessage] = useState('');
   const [toastTitle, setToastTitle] = useState('');
-  const [showSuccess, setShowSuccess] = useState(false);
-  const [userName, setUserName] = useState('');
 
   const handleCloseToast = React.useCallback(() => {
     setShowToast(false);
   }, []);
 
-  const handleInputChange = (e) => {
-    const { name, value } = e.target;
-    if (name === 'email') {
-      setEmail(value);
-    } else if (name === 'name') {
-      setName(value);
-    }
-
-    if (showToast) {
-      setShowToast(false);
-    }
+  const showError = (title, message) => {
+    setToastType('error');
+    setToastTitle(title);
+    setToastMessage(message);
+    setShowToast(true);
   };
 
-  const handleSubmit = async (e) => {
+  const handleSendOtp = async (e) => {
     e.preventDefault();
+    setIsSubmitting(true);
     try {
-      const result = await requestEmailVerification(email, name);
-      if (result.success) {
-        setUserName(name);
-        setToastType('success');
-        setToastTitle('비밀번호 재설정 링크 발송');
-        setToastMessage(`${name} 님의 메일로 재설정 링크가 발송되었어요.`);
-        setShowToast(true);
-        setShowSuccess(true);
-      } else {
-        setToastType('error');
-        setToastTitle('일치하는 정보 없음');
-        setToastMessage('계정이 존재하는지 다시 확인해 주세요.');
-        setShowToast(true);
-      }
+      await axiosInstance.post('auth/email/send-otp', {
+        email,
+        purpose: 'PASSWORD_RESET',
+      });
+      setStep(STEP.OTP);
     } catch (error) {
-      console.error('PwChange component error:', error);
-      setToastType('error');
-      setToastTitle('일치하는 정보 없음');
-      setToastMessage('계정이 존재하는지 다시 확인해 주세요.');
-      setShowToast(true);
+      const status = error.response?.status;
+      if (status === 429) {
+        showError('요청 한도 초과', '잠시 후 다시 시도해주세요.');
+      } else {
+        showError('발송 실패', '인증번호 발송에 실패했습니다. 이메일을 확인해주세요.');
+      }
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
-  if (showSuccess) {
+  const handleChangePassword = async (e) => {
+    e.preventDefault();
+    if (newPassword !== confirmPassword) {
+      showError('비밀번호 불일치', '새 비밀번호가 일치하지 않습니다.');
+      return;
+    }
+    if (newPassword.length < 8) {
+      showError('비밀번호 오류', '비밀번호는 8자 이상이어야 합니다.');
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      await axiosInstance.post('auth/password/change', {
+        email,
+        otp_code: otpCode,
+        new_password: newPassword,
+      });
+      setStep(STEP.SUCCESS);
+    } catch (error) {
+      const status = error.response?.status;
+      if (status === 401) {
+        showError('인증 실패', '인증번호가 올바르지 않습니다.');
+      } else if (status === 404) {
+        showError('인증번호 없음', '인증번호를 먼저 요청해주세요.');
+      } else {
+        showError('변경 실패', '비밀번호 변경에 실패했습니다. 다시 시도해주세요.');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (step === STEP.SUCCESS) {
     return (
       <L.Container>
         <L.SuccessContainer>
           <L.LogoWrapping onClick={() => navigate('/')} style={{ cursor: 'pointer' }}>
             <L.LogoImg src="/assets/occount-logo.svg" alt="logo" />
           </L.LogoWrapping>
-          <L.SuccessMessage>{userName} 님의 이메일로 재설정 링크가 전달되었어요!</L.SuccessMessage>
-          <L.SuccessSubMessage>로그인 후에 OCCOUNT의 서비스를 이용해보세요</L.SuccessSubMessage>
+          <L.SuccessMessage>비밀번호가 변경되었습니다!</L.SuccessMessage>
+          <L.SuccessSubMessage>새 비밀번호로 로그인해주세요</L.SuccessSubMessage>
           <L.LoginButton onClick={() => navigate('/login')}>로그인하러가기</L.LoginButton>
         </L.SuccessContainer>
       </L.Container>
@@ -85,29 +114,58 @@ function PwChange() {
           <L.LogoSubText>비밀번호 찾기</L.LogoSubText>
         </L.LogoContainer>
 
-        <L.PwChangeWrap onSubmit={handleSubmit}>
-          <L.FormContainer>
-            <L.InputContainer>
-              <L.PwChangeInput
-                type="text"
-                name="name"
-                value={name}
-                onChange={handleInputChange}
-                placeholder="이름을 입력해주세요"
-                required
-              />
-              <L.PwChangeInput
-                type="email"
-                name="email"
-                value={email}
-                onChange={handleInputChange}
-                placeholder="이메일을 입력해주세요"
-                required
-              />
-            </L.InputContainer>
-            <L.PwChangeButton type="submit">본인확인</L.PwChangeButton>
-          </L.FormContainer>
-        </L.PwChangeWrap>
+        {step === STEP.EMAIL && (
+          <L.PwChangeWrap onSubmit={handleSendOtp}>
+            <L.FormContainer>
+              <L.InputContainer>
+                <L.PwChangeInput
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="이메일을 입력해주세요"
+                  required
+                />
+              </L.InputContainer>
+              <L.PwChangeButton type="submit" disabled={isSubmitting}>
+                {isSubmitting ? '발송 중...' : '인증번호 받기'}
+              </L.PwChangeButton>
+            </L.FormContainer>
+          </L.PwChangeWrap>
+        )}
+
+        {step === STEP.OTP && (
+          <L.PwChangeWrap onSubmit={handleChangePassword}>
+            <L.FormContainer>
+              <L.InputContainer>
+                <L.PwChangeInput
+                  type="text"
+                  value={otpCode}
+                  onChange={(e) => setOtpCode(e.target.value)}
+                  placeholder="인증번호 6자리"
+                  maxLength={6}
+                  required
+                />
+                <L.PwChangeInput
+                  type="password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  placeholder="새 비밀번호 (8자 이상)"
+                  required
+                />
+                <L.PwChangeInput
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  placeholder="새 비밀번호 확인"
+                  required
+                />
+              </L.InputContainer>
+              <L.PwChangeButton type="submit" disabled={isSubmitting}>
+                {isSubmitting ? '변경 중...' : '비밀번호 변경'}
+              </L.PwChangeButton>
+            </L.FormContainer>
+          </L.PwChangeWrap>
+        )}
       </L.LogoAndForm>
 
       <Toast

--- a/src/components/User/pwChange/index.jsx
+++ b/src/components/User/pwChange/index.jsx
@@ -48,7 +48,7 @@ function PwChange() {
     } catch (error) {
       const status = error.response?.status;
       if (status === 429) {
-        showError('요청 한도 초과', '잠시 후 다시 시도해주세요.');
+        showError('요청 한도 초과', error.response?.data?.message || '잠시 후 다시 시도해주세요.');
       } else {
         showError('발송 실패', '인증번호 발송에 실패했습니다. 이메일을 확인해주세요.');
       }

--- a/src/utils/Axios.ts
+++ b/src/utils/Axios.ts
@@ -185,7 +185,10 @@ axiosInstance.interceptors.response.use(
       // 로그인과 비밀번호 확인 요청은 401 에러가 발생해도 로그아웃 처리하지 않음
       if (
         originalRequest &&
-        (originalRequest.url === 'auth/login' || originalRequest.url === 'account/verify')
+        (originalRequest.url === 'auth/login' ||
+          originalRequest.url === 'account/verify' ||
+          originalRequest.url === 'auth/password/change' ||
+          originalRequest.url === 'auth/email/send-otp')
       ) {
         return Promise.reject(error);
       }


### PR DESCRIPTION
## 요약

<!-- 이번 PR에서 작업한 내용을 한두 문장으로 요약해주세요. -->

- 회원가입 페이지에서 이동하는 비밀번호 찾기 v3 api 연동

## 목적

<!-- 왜 이 작업이 필요한지 작성해주세요. -->

- 비밀번호를 잊어 로그인 자체를 못하는 상황이 발생함

## 변경 사항

<!-- 주요 변경 사항을 작성해주세요. -->

- 이름+이메일을 통한 본인인증 방식에서 v3의 otp 인증으로 변경

## PR 업로드 전 체크리스트

<!-- PR 업로드 전 확인한 내용을 체크해주세요. 프로젝트 또는 변경 사항에 해당하지 않는 경우 N/A에 체크해주세요. -->

- [x] `yarn build` 완료
- [x] lint/format 완료
- [x] 주요 화면 동작 확인
- [x] 관련 기능 수동 테스트
- [ ] N/A

## 영향 범위

<!-- 해당하는 항목에 체크해주세요. -->

- [x] UI
- [x] API 연동
- [x] 인증/권한
- [ ] 라우팅
- [ ] 상태 관리
- [ ] 성능
- [ ] 빌드/설정
- [ ] 문서
- [ ] 기타

## 스크린샷 / 화면 녹화

<!-- UI 변경이 있다면 AS-IS와 TO-BE를 첨부해주세요. 없으면 N/A 작성 -->

| AS-IS | TO-BE |
| --- | --- |
| N/A | N/A |

## 리뷰 포인트

<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분을 작성해주세요. -->

N/A

## 후속 작업

<!-- 이번 PR에서 하지 않은 작업이나 이어서 해야 할 작업이 있다면 작성해주세요. -->

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Redesigned password reset flow to include email verification and OTP confirmation
  * Added password field validation to ensure matching confirmation entries
  * Improved error messaging through enhanced notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->